### PR TITLE
some fixes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,5 +5,5 @@ load(
 
 container_image(
   name = "mymysql",
-  base = "@mysql",
+  base = "@mysql//image",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,7 +46,7 @@ load(
 )
 container_pull(
   name = "mysql",
-  registry = "docker.io",
-  repository = "msql",
-  digest = "sha256:c3594c6528b31c6222ba426d836600abd45f554d078ef661d3c882604c70ad0a"
+  registry = "index.docker.io",
+  repository = "library/mysql",
+  digest = "sha256:710c9ca6c4df66bf0c93df0d761e0519018fa2f0edb8015bb0db6c7c3919a8e2"
 )


### PR DESCRIPTION
 In the WORKSPACE file:

 * for official images, repository needs to be named `library/<name>`
 * The url of the docker `registry` is `index.docker.io`
 * The `digest` was the digest of the multiarch-list of images and not of the image itself (bazel would have told you that, once the first two errors are fixed)

In the BUILD file:

 * Images can be referenced via the `//image` attribute of the target. Therefore `@mysql//image` instead of `@mysql`.